### PR TITLE
Add support for reading and writing user ratings in Subsonic and Ampache

### DIFF
--- a/src/components/Actions/Actions.tsx
+++ b/src/components/Actions/Actions.tsx
@@ -81,6 +81,8 @@ export default function Actions({item, inline}: ActionsProps) {
         [item]
     );
 
+    const ratingIncrement = (service?.id === "ampache" || service?.id === "subsonic") ? 1 : 0.5;
+    
     return (
         <IconButtons>
             {inline ? (
@@ -106,8 +108,8 @@ export default function Actions({item, inline}: ActionsProps) {
             {service ? (
                 <>
                     {item.rating !== undefined && service?.canRate?.(item, inline) ? (
-                        service.id === 'plex' ? (
-                            <StarRating value={item.rating} tabIndex={tabIndex} onChange={rate} />
+                        service.id === 'plex' || service.id === 'ampache' || service.id === 'subsonic' ? (                            
+                            <StarRating value={item.rating} tabIndex={tabIndex} onChange={rate} increment={ratingIncrement} />
                         ) : (
                             <IconButton
                                 icon={

--- a/src/services/subsonic/factory/SubsonicApi.ts
+++ b/src/services/subsonic/factory/SubsonicApi.ts
@@ -506,4 +506,10 @@ export default class SubsonicApi {
             })) || []
         );
     }
+
+    async setRating(src: string, rating: 0 | 1 | 2 | 3 | 4 | 5): Promise<void> {
+        const [, , id] = src.split(':');
+        const params = new URLSearchParams({id: id, rating: rating.toString()});
+        await this.get(`setRating?${params}`);
+    }
 }

--- a/src/services/subsonic/factory/SubsonicPager.ts
+++ b/src/services/subsonic/factory/SubsonicPager.ts
@@ -155,7 +155,8 @@ export default class SubsonicPager<T extends MediaObject> implements Pager<T> {
             recording_mbid: typeof song.musicBrainzId === 'string' ? song.musicBrainzId : undefined,
             albumGain: song.replayGain?.albumGain,
             trackGain: song.replayGain?.trackGain,
-        };
+            rating: song.userRating,
+        };        
     }
 
     private createMediaItemFromVideo(video: Subsonic.Video): SetRequired<MediaItem, 'fileName'> {

--- a/src/services/subsonic/types.d.ts
+++ b/src/services/subsonic/types.d.ts
@@ -58,6 +58,7 @@ declare namespace Subsonic {
         readonly albumId: string;
         readonly artist: string;
         readonly artistId: string;
+        readonly averageRating: AverageRating;
         readonly bitRate: number;
         readonly contentType: string;
         readonly coverArt: string;
@@ -77,6 +78,7 @@ declare namespace Subsonic {
         readonly title: string;
         readonly track: number;
         readonly type: 'music';
+        readonly userRating: UserRating;
         readonly year?: number;
         // OpenSubsonic extensions
         readonly musicBrainzId?: string;
@@ -85,6 +87,9 @@ declare namespace Subsonic {
             readonly trackGain: number;
         };
     }
+
+    type AverageRating = 1 | 2 | 3 | 4 | 5;
+    type UserRating = 1 | 2 | 3 | 4 | 5;
 
     interface Video {
         readonly album: string;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/441d8fe0-0030-4bb9-9d10-528631876829)

This PR adds support for reading and writing user ratings to Ampache/Subsonic. Tested using Ampache 7.4.2.