### PR TITLE
Apple Music: Fix the favorite songs playlist not being found

### DIFF
--- a/src/services/apple/appleAuth.ts
+++ b/src/services/apple/appleAuth.ts
@@ -132,13 +132,12 @@ async function getFavoriteSongsId(
     musicKit: MusicKit.MusicKitInstance,
     url: string
 ): Promise<string> {
-    const limit = 100;
     const {
         data: { data: playlists = [], next },
     } = await musicKit.api.music(url, {
         'extend[library-playlists]': 'tags',
         'fields[library-playlists]': 'tags',
-        limit
+        limit: 100
     });
 
     const favoriteSongs = playlists.find((playlist: any) =>


### PR DESCRIPTION
Weirdly enough, the old endpoint only returns user-created playlists from what I've seen. I found this new one while inspecting the requests on AM’s website. Despite the name, the user doesn’t need to have a playlist folder.