### PR TITLE
Explicitly set StartupWMClass on Linux builds

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -84,6 +84,11 @@
                 "tar.xz"
             ],
             "icon": "assets/icons/ampcast.png",
+            "desktop": {
+              "entry": {
+                "startupWMClass": "ampcast"
+              }
+            },
             "category": "AudioVideo;Audio;Player"
         },
         "nsis": {


### PR DESCRIPTION
electron-builder is setting `ampcast-app` by default (presumably because that's the package name), the app window uses only `ampcast` instead, which doesn't help window managers to properly map the window to its according desktop file entry (it might show up as a random window with either a Wayland or X11 logo on a taskbar if you're using a desktop environment such as KDE)