### PR TITLE
feat: optionally show bpm

### DIFF
--- a/src/components/MediaList/layouts.ts
+++ b/src/components/MediaList/layouts.ts
@@ -23,6 +23,7 @@ export const allMediaItemFields: readonly Field[] = [
     'Rating',
     'AddedAt',
     'BitRate',
+    'Bpm',
     'Container',
 ];
 

--- a/src/components/MediaList/mediaListFields.tsx
+++ b/src/components/MediaList/mediaListFields.tsx
@@ -68,6 +68,8 @@ export const IconTitle: RenderField = (item, info) => {
 
 const BitRate: RenderField<MediaItem> = (item) => <Text value={item.bitRate} />;
 
+const Bpm: RenderField<MediaItem> = (item) => <Text value={item.bpm || ''} />;
+
 const Container: RenderField<MediaItem> = (item) => <Text value={item.badge} />;
 
 const Description: RenderField = (item) => <Text value={item.description} />;
@@ -434,6 +436,14 @@ const mediaListFields: Record<Field, FieldSpec> = {
         align: 'right',
         width: 6,
         className: 'bitrate',
+    },
+    Bpm: {
+        id: 'Bpm',
+        title: 'BPM',
+        render: Bpm,
+        align: 'right',
+        width: 5,
+        className: 'bpm',
     },
     Container: {
         id: 'Container',

--- a/src/services/metadata/sorter.ts
+++ b/src/services/metadata/sorter.ts
@@ -35,6 +35,7 @@ const sortTypes: Record<Field, SortType> = {
     Genre: 'locale',
     Owner: 'locale',
     BitRate: 'number',
+    Bpm: 'number',
     Container: 'locale',
     Copyright: 'locale',
     AddedAt: 'number',
@@ -201,6 +202,8 @@ function getNumber<T extends MediaObject>(item: T, field: Field): number {
             return (item as MediaAlbum).trackCount || 0;
         case 'BitRate':
             return (item as MediaItem).bitRate || 0;
+        case 'Bpm':
+            return (item as MediaItem).bpm || 0;
         case 'Rating':
             return (item as MediaItem).rating || 0;
         default:

--- a/src/services/navidrome/navidromeUtils.ts
+++ b/src/services/navidrome/navidromeUtils.ts
@@ -114,6 +114,7 @@ function createMediaItem(song: Navidrome.Song): MediaItem {
         trackGain: song.rgTrackGain,
         trackPeak: song.rgTrackPeak,
         bitRate: song.bitRate,
+        bpm: song.bpm,
         badge: song.suffix,
         container: song.suffix,
         unplayable: song.missing || undefined,

--- a/src/services/navidrome/types.d.ts
+++ b/src/services/navidrome/types.d.ts
@@ -65,6 +65,7 @@ declare namespace Navidrome {
         readonly artistId: string;
         readonly bitRate: number;
         readonly bookmarkPosition: number;
+        readonly bpm?: number;
         readonly catalogNum: string;
         readonly channels: number;
         readonly compilation: boolean;

--- a/src/services/subsonic/factory/SubsonicUtils.ts
+++ b/src/services/subsonic/factory/SubsonicUtils.ts
@@ -153,6 +153,7 @@ export default class SubsonicUtils {
             genres: song.genre ? [song.genre] : undefined,
             thumbnails: this.createThumbnails(song.coverArt),
             bitRate: song.bitRate,
+            bpm: song.bpm,
             badge: song.suffix,
             container: song.contentType?.replace('audio/', ''),
             // OpenSubsonic extensions

--- a/src/types/MediaItem.d.ts
+++ b/src/types/MediaItem.d.ts
@@ -47,6 +47,7 @@ export default interface MediaItem extends BaseMediaObject {
     // Badges.
     readonly badge?: string;
     readonly bitRate?: number;
+    readonly bpm?: number;
     readonly container?: string;
     readonly explicit?: boolean;
     readonly shareLink?: string;

--- a/src/types/MediaListLayout.d.ts
+++ b/src/types/MediaListLayout.d.ts
@@ -33,6 +33,7 @@ export type Field =
     | 'LastPlayed'
     | 'ListenDate'
     | 'BitRate'
+    | 'Bpm'
     | 'Badges'
     | 'Container'
     | 'Thumbnail'


### PR DESCRIPTION
# What does this do?

This PR adds BPM as an opt-in column for track lists. This field is provided by Subsonic and Navidrome it just wasn't being exposed in ampcast. Other sources are untouched and will simply show a blank BPM column, same as BitRate/Container already do for sources that don't provide them.

## Screenshots / Testing
I tested on my self-hosted navidrome server:

<img width="560" height="484" alt="Screenshot 2026-07-22 at 10 42 15 AM" src="https://github.com/user-attachments/assets/069da787-42cc-453c-b097-5e32e9b4d976" />

** adding Bpm to track fields**

<img width="760" height="506" alt="Screenshot 2026-07-22 at 10 42 27 AM" src="https://github.com/user-attachments/assets/2939747b-e344-49d1-b732-1dd62dbac9c9" />

** bpm is visible in the track list **


<img width="497" height="105" alt="Screenshot 2026-07-22 at 10 43 31 AM" src="https://github.com/user-attachments/assets/c9719f35-95ab-4526-87b2-fc98c6ec0709" />
<img width="495" height="88" alt="Screenshot 2026-07-22 at 10 43 35 AM" src="https://github.com/user-attachments/assets/5f2efe87-2858-420a-a037-b409d2227460" />

** in playlists you can sort by bpm. **