### PR TITLE
mp3 playlist exporter

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -14,7 +14,8 @@
                 "electron-store": "^11.0.2",
                 "electron-unhandled": "^5.0.0",
                 "electron-updater": "^6.3.2",
-                "electron-window-state": "^5.0.3"
+                "electron-window-state": "^5.0.3",
+                "node-id3": "^0.2.9"
             },
             "devDependencies": {
                 "@electron/notarize": "^3.1.0",
@@ -307,6 +308,7 @@
             "dev": true,
             "license": "BSD-2-Clause",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "cross-dirname": "^0.1.0",
                 "debug": "^4.3.4",
@@ -328,6 +330,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -344,6 +347,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "universalify": "^2.0.0"
             },
@@ -1379,7 +1383,8 @@
             "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
             "dev": true,
             "license": "MIT",
-            "optional": true
+            "optional": true,
+            "peer": true
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -1594,7 +1599,6 @@
             "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "app-builder-lib": "26.15.3",
                 "builder-util": "26.15.3",
@@ -1900,6 +1904,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@electron/asar": "^3.2.1",
                 "debug": "^4.1.1",
@@ -1920,6 +1925,7 @@
             "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -1935,6 +1941,7 @@
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -2620,6 +2627,18 @@
                 "node": ">= 14"
             }
         },
+        "node_modules/iconv-lite": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.2.tgz",
+            "integrity": "sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/inflight": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -3119,6 +3138,15 @@
                 "node": "^20.17.0 || >=22.9.0"
             }
         },
+        "node_modules/node-id3": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/node-id3/-/node-id3-0.2.9.tgz",
+            "integrity": "sha512-dSxhuxrkkGVRgUhDHFxdY0pilzOREcodO01HcZWfaRkCaPWGmo0dOgD8ygyL6ln4Iv4cmfRxAWn1WD9bIB9Bhw==",
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "0.6.2"
+            }
+        },
         "node_modules/node-int64": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -3259,7 +3287,6 @@
             "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -3320,6 +3347,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "dependencies": {
                 "commander": "^9.4.0"
             },
@@ -3337,6 +3365,7 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
+            "peer": true,
             "engines": {
                 "node": "^12.20.0 || >=14"
             }
@@ -3556,6 +3585,7 @@
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -3587,6 +3617,12 @@
             "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
             "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/safer-buffer": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+            "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "license": "MIT"
         },
         "node_modules/sanitize-filename": {
@@ -3917,6 +3953,7 @@
             "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "mkdirp": "^0.5.1",
                 "rimraf": "~2.6.2"

--- a/app/package.json
+++ b/app/package.json
@@ -32,7 +32,8 @@
         "electron-store": "^11.0.2",
         "electron-unhandled": "^5.0.0",
         "electron-updater": "^6.3.2",
-        "electron-window-state": "^5.0.3"
+        "electron-window-state": "^5.0.3",
+        "node-id3": "^0.2.9"
     },
     "engines": {
         "node": ">=24.x",

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -2,6 +2,7 @@ import {
     app,
     components,
     desktopCapturer,
+    dialog,
     ipcMain,
     protocol,
     safeStorage,
@@ -17,6 +18,8 @@ import unhandled from 'electron-unhandled';
 import windowStateKeeper from 'electron-window-state';
 import Store from 'electron-store';
 import path from 'node:path';
+import {execFile} from 'node:child_process';
+import {Worker} from 'node:worker_threads';
 import {__dirname} from './config.js';
 import server from './server.js';
 import store from './store.js';
@@ -44,6 +47,8 @@ const loginUrls = [
 ];
 
 let mainWindow;
+const playlistExports = new Map();
+const playlistExportDestinations = new Map();
 
 async function createSplashScreen(mainWindowState) {
     const {x, y, width, height} = mainWindowState;
@@ -217,6 +222,312 @@ function createBridge() {
     ipcMain.handle('disable-loopback-audio', () => {
         mainWindow?.webContents.session.setDisplayMediaRequestHandler(null);
     });
+
+    ipcMain.on('cancel-playlist-export', (_, operationId) => {
+        playlistExports.get(operationId)?.cancel();
+    });
+    ipcMain.on('clear-playlist-export-batch', (_, batchId) => {
+        playlistExportDestinations.delete(batchId);
+    });
+    ipcMain.handle('get-removable-export-targets', getRemovableExportTargets);
+
+    ipcMain.handle('export-playlist', async (event, request) => {
+        const tracks = Array.isArray(request?.tracks) ? request.tracks : [];
+        if (tracks.length === 0) {
+            return {canceled: false, exported: 0, skipped: request?.skipped || 0, errors: []};
+        }
+        let canceled = false;
+        const pendingExport = {cancel: () => (canceled = true)};
+        playlistExports.set(request.operationId, pendingExport);
+
+        let destination = playlistExportDestinations.get(request.batchId);
+        if (!destination) {
+            if (request.destination) {
+                const targets = await getRemovableExportTargets();
+                const requestedPath = path.resolve(request.destination);
+                const target = targets.find(
+                    ({path: targetPath}) => path.resolve(targetPath) === requestedPath
+                );
+                if (!target) {
+                    playlistExports.delete(request.operationId);
+                    throw Error('The selected removable drive is no longer available');
+                }
+                destination = target.path;
+            } else {
+                const selection = await dialog.showOpenDialog(mainWindow, {
+                    title: 'Export playlist to MP3',
+                    buttonLabel: 'Export here',
+                    properties: ['openDirectory', 'createDirectory'],
+                });
+                if (
+                    selection.canceled ||
+                    !selection.filePaths[0] ||
+                    canceled
+                ) {
+                    playlistExports.delete(request.operationId);
+                    return {canceled: true, exported: 0, skipped: 0, errors: []};
+                }
+                destination = selection.filePaths[0];
+            }
+            playlistExportDestinations.set(request.batchId, destination);
+        }
+
+        try {
+            if (canceled) {
+                return {canceled: true, exported: 0, skipped: 0, errors: []};
+            }
+            return await runPlaylistExportWorker(event, request, destination, pendingExport);
+        } finally {
+            playlistExports.delete(request.operationId);
+        }
+    });
+}
+
+function runPlaylistExportWorker(event, request, destination, pendingExport) {
+    return new Promise((resolve, reject) => {
+        const worker = new Worker(new URL('./playlistExportWorker.js', import.meta.url), {
+            workerData: {request, destination},
+        });
+        let settled = false;
+        pendingExport.cancel = () => worker.postMessage({type: 'cancel'});
+
+        worker.on('message', (message) => {
+            if (message?.type === 'progress') {
+                if (!event.sender.isDestroyed()) {
+                    event.sender.send('export-playlist-progress', {
+                        operationId: request.operationId,
+                        ...message.progress,
+                    });
+                }
+            } else if (message?.type === 'result') {
+                settled = true;
+                resolve(message.result);
+            } else if (message?.type === 'error') {
+                settled = true;
+                reject(Error(message.error));
+            }
+        });
+        worker.once('error', (err) => {
+            if (!settled) {
+                settled = true;
+                reject(err);
+            }
+        });
+        worker.once('exit', (code) => {
+            if (!settled) {
+                settled = true;
+                reject(Error(`Playlist export worker stopped unexpectedly (${code})`));
+            }
+        });
+    });
+}
+
+async function getRemovableExportTargets() {
+    if (process.platform !== 'win32') return [];
+    const script = [
+        '$items = @(Get-CimInstance Win32_LogicalDisk -Filter "DriveType=2" | ForEach-Object {',
+        '  $letter = $_.DeviceID',
+        '  [PSCustomObject]@{ path = "$letter\\"; label = if ($_.VolumeName) { "$($_.VolumeName) ($letter)" } else { "USB drive ($letter)" }; freeBytes = [double]$_.FreeSpace; totalBytes = [double]$_.Size }',
+        '})',
+        '$items | ConvertTo-Json -Compress',
+    ].join('; ');
+    const stdout = await new Promise((resolve, reject) => {
+        execFile(
+            'powershell.exe',
+            ['-NoProfile', '-NonInteractive', '-Command', script],
+            {
+                encoding: 'utf8',
+                windowsHide: true,
+                maxBuffer: 1024 * 1024,
+                timeout: 5000,
+                killSignal: 'SIGKILL',
+            },
+            (err, output) => (err ? reject(err) : resolve(output))
+        );
+    });
+    if (!String(stdout).trim()) return [];
+    const parsed = JSON.parse(stdout);
+    return (Array.isArray(parsed) ? parsed : [parsed]).filter(
+        (target) => target?.path && target?.label
+    );
+}
+
+function sendExportProgress(event, operationId, progress) {
+    if (!event.sender.isDestroyed()) {
+        event.sender.send('export-playlist-progress', {operationId, ...progress});
+    }
+}
+
+function sanitizeFileName(value) {
+    const sanitized = String(value)
+        .replace(/[<>:"/\\|?*\u0000-\u001f]/g, '_')
+        .replace(/[. ]+$/g, '')
+        .trim();
+    return sanitized.slice(0, 180) || 'Untitled';
+}
+
+function createM3uEntry(track, fileName) {
+    const displayName = `${track.artist ? `${track.artist} - ` : ''}${track.title || fileName}`;
+    return [
+        `#AMPCAST-ID:${encodeURIComponent(track.id || '')}`,
+        `#EXTINF:${Math.round(track.duration || -1)},${displayName.replace(/[\r\n]/g, ' ')}`,
+        fileName,
+    ];
+}
+
+function getExportFileName(track, index, total) {
+    const prefix = String(index + 1).padStart(String(total).length, '0');
+    const baseName = sanitizeFileName(
+        track.fileName || `${track.title || `Track ${index + 1}`}.mp3`
+    );
+    return `${prefix} - ${baseName}`;
+}
+
+async function isNonEmptyFile(filePath) {
+    try {
+        const stats = await fsPromises.stat(filePath);
+        return stats.isFile() && stats.size > 0;
+    } catch {
+        return false;
+    }
+}
+
+function createM3uFile(bitRate, entries) {
+    return `${[
+        '#EXTM3U',
+        `#AMPCAST:BITRATE=${Number(bitRate)}`,
+        '#AMPCAST:TAGS=1',
+        ...entries,
+    ].join('\r\n')}\r\n`;
+}
+
+async function readManagedPlaylist(playlistPath) {
+    try {
+        const contents = await fsPromises.readFile(playlistPath, 'utf8');
+        const bitRate = Number(contents.match(/^#AMPCAST:BITRATE=(\d+)\r?$/m)?.[1]) || 0;
+        const tagVersion = Number(contents.match(/^#AMPCAST:TAGS=(\d+)\r?$/m)?.[1]) || 0;
+        const entries = [];
+        let id;
+        for (const rawLine of contents.split(/\r?\n/)) {
+            const line = rawLine.trim();
+            if (line.startsWith('#AMPCAST-ID:')) {
+                try {
+                    id = decodeURIComponent(line.slice('#AMPCAST-ID:'.length));
+                } catch {
+                    id = undefined;
+                }
+            } else if (line && !line.startsWith('#') && path.basename(line) === line) {
+                entries.push({id, fileName: line});
+                id = undefined;
+            }
+        }
+        const files = new Set(
+            entries.map(({fileName}) => fileName)
+        );
+        return {bitRate, tagVersion, files, entries};
+    } catch {
+        return {bitRate: 0, tagVersion: 0, files: new Set(), entries: []};
+    }
+}
+
+async function reconcileExportedTrackNames(oldPlaylist, tracks, exportDirectory) {
+    const unused = new Set(oldPlaylist.entries);
+    const assignments = [];
+    for (let index = 0; index < tracks.length; index++) {
+        const track = tracks[index];
+        const desiredName = getExportFileName(track, index, tracks.length);
+        const desiredBase = stripTrackPosition(desiredName);
+        let entry = [...unused].find(({id}) => id && id === track.id);
+        entry ||= [...unused].find(
+            ({fileName}) => stripTrackPosition(fileName).toLowerCase() === desiredBase.toLowerCase()
+        );
+        if (!entry) continue;
+        const sourcePath = path.join(exportDirectory, entry.fileName);
+        if (!(await isNonEmptyFile(sourcePath))) continue;
+        unused.delete(entry);
+        if (entry.fileName !== desiredName) {
+            assignments.push({sourcePath, destinationPath: path.join(exportDirectory, desiredName)});
+        }
+    }
+
+    const staged = [];
+    for (const assignment of assignments) {
+        const temporaryPath = `${assignment.sourcePath}.reorder-${crypto.randomUUID()}`;
+        await fsPromises.rename(assignment.sourcePath, temporaryPath);
+        staged.push({...assignment, temporaryPath});
+    }
+    for (const {temporaryPath, destinationPath} of staged) {
+        await fsPromises.rm(destinationPath, {force: true});
+        await fsPromises.rename(temporaryPath, destinationPath);
+    }
+}
+
+function stripTrackPosition(fileName) {
+    return fileName.replace(/^\d+ - /, '');
+}
+
+async function writeCarCompatibleTags(track, filePath, artworkCache, signal) {
+    const tags = {
+        title: String(track.title || ''),
+        artist: String(track.artist || track.albumArtist || ''),
+        performerInfo: String(track.albumArtist || track.artist || ''),
+        album: String(track.album || ''),
+        trackNumber: track.track ? String(track.track) : undefined,
+        partOfSet: track.disc ? String(track.disc) : undefined,
+        year: track.year ? String(track.year) : undefined,
+    };
+    if (track.artworkUrl) {
+        let imageBuffer;
+        try {
+            imageBuffer = await getArtwork(track.artworkUrl, artworkCache, signal);
+        } catch (err) {
+            if (signal.aborted) throw err;
+            log.warn(`Could not embed artwork for ${track.title || 'track'}:`, err);
+        }
+        if (imageBuffer) {
+            tags.image = {
+                mime: 'image/jpeg',
+                type: {id: 3, name: 'front cover'},
+                description: 'Cover',
+                imageBuffer,
+            };
+        }
+    }
+    const result = NodeID3.update(tags, filePath);
+    if (result instanceof Error) {
+        throw result;
+    }
+}
+
+async function getArtwork(url, cache, signal) {
+    if (!cache.has(url)) {
+        cache.set(
+            url,
+            (async () => {
+                const response = await fetch(url, {redirect: 'follow', signal});
+                if (!response.ok) {
+                    throw Error(`Artwork HTTP ${response.status}`);
+                }
+                const declaredSize = Number(response.headers.get('content-length')) || 0;
+                if (declaredSize > 5 * 1024 * 1024) {
+                    throw Error('Artwork is larger than 5 MB');
+                }
+                const buffer = Buffer.from(await response.arrayBuffer());
+                if (buffer.length > 5 * 1024 * 1024) {
+                    throw Error('Artwork is larger than 5 MB');
+                }
+                return buffer;
+            })()
+        );
+    }
+    return cache.get(url);
+}
+
+async function replaceTextFile(filePath, contents) {
+    const partialPath = `${filePath}.part`;
+    await fsPromises.writeFile(partialPath, contents, 'utf8');
+    await fsPromises.rm(filePath, {force: true});
+    await fsPromises.rename(partialPath, filePath);
 }
 
 async function checkForUpdatesAndNotify() {

--- a/app/src/playlistExportWorker.js
+++ b/app/src/playlistExportWorker.js
@@ -1,0 +1,324 @@
+import {parentPort, workerData} from 'node:worker_threads';
+import crypto from 'node:crypto';
+import path from 'node:path';
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import {Readable, Transform} from 'node:stream';
+import {pipeline} from 'node:stream/promises';
+import NodeID3 from 'node-id3';
+
+const {request, destination} = workerData;
+const tracks = Array.isArray(request?.tracks) ? request.tracks : [];
+const abortController = new AbortController();
+let lastProgressAt = 0;
+
+parentPort.on('message', (message) => {
+    if (message?.type === 'cancel') abortController.abort();
+});
+
+run().then(
+    (result) => {
+        parentPort.postMessage({type: 'result', result});
+        parentPort.close();
+    },
+    (err) => {
+        parentPort.postMessage({type: 'error', error: err?.message || String(err)});
+        parentPort.close();
+    }
+);
+
+async function run() {
+    const playlistName = sanitizeFileName(request?.name || 'Ampcast playlist');
+    const exportDirectory = path.join(destination, playlistName);
+    await fsPromises.mkdir(exportDirectory, {recursive: true});
+    const playlistPath = path.join(exportDirectory, `${playlistName}.m3u8`);
+    const oldPlaylist = await readManagedPlaylist(playlistPath);
+    const canReuseFiles =
+        oldPlaylist.bitRate === Number(request.bitRate) && oldPlaylist.tagVersion === 1;
+    const artworkCache = new Map();
+    if (canReuseFiles) {
+        await reconcileExportedTrackNames(oldPlaylist, tracks, exportDirectory);
+    }
+
+    const errors = [];
+    const playlistEntries = new Array(tracks.length);
+    let exported = 0;
+    let reservedBytes = 0;
+    let nextTrackIndex = 0;
+    const {bavail, bsize} = await fsPromises.statfs(exportDirectory);
+    const availableBytes = Number(bavail) * Number(bsize);
+
+    const exportTrack = async (index) => {
+        const track = tracks[index];
+        if (abortController.signal.aborted) return;
+        try {
+            const fileName = getExportFileName(track, index, tracks.length);
+            const finalPath = path.join(exportDirectory, fileName);
+            if (canReuseFiles && (await isNonEmptyFile(finalPath))) {
+                exported++;
+                playlistEntries[index] = createM3uEntry(track, fileName);
+                sendProgress({
+                    completed: exported,
+                    total: tracks.length,
+                    title: track.title || fileName,
+                    bytesWritten: 0,
+                }, exported === tracks.length);
+                return;
+            }
+
+            const response = await fetch(track.url, {
+                redirect: 'follow',
+                signal: abortController.signal,
+            });
+            if (!response.ok || !response.body) throw Error(`HTTP ${response.status}`);
+            const contentLength = Number(response.headers.get('content-length')) || 0;
+            reservedBytes += contentLength;
+            if (contentLength && reservedBytes > availableBytes) {
+                throw Error('Not enough free space on the destination drive');
+            }
+
+            const partialPath = `${finalPath}.part`;
+            await fsPromises.rm(partialPath, {force: true});
+            let bytesWritten = 0;
+            const progressStream = new Transform({
+                transform(chunk, _, callback) {
+                    bytesWritten += chunk.length;
+                    sendProgress({
+                        completed: exported,
+                        total: tracks.length,
+                        bytesWritten,
+                        totalBytes: contentLength || undefined,
+                    });
+                    callback(null, chunk);
+                },
+            });
+            try {
+                await pipeline(
+                    Readable.fromWeb(response.body),
+                    progressStream,
+                    fs.createWriteStream(partialPath, {flags: 'wx'}),
+                    {signal: abortController.signal}
+                );
+                await writeCarCompatibleTags(
+                    track,
+                    partialPath,
+                    artworkCache,
+                    abortController.signal
+                );
+                await fsPromises.rm(finalPath, {force: true});
+                await fsPromises.rename(partialPath, finalPath);
+            } catch (err) {
+                await fsPromises.rm(partialPath, {force: true});
+                throw err;
+            }
+
+            exported++;
+            playlistEntries[index] = createM3uEntry(track, fileName);
+            sendProgress({
+                completed: exported,
+                total: tracks.length,
+                title: track.title || fileName,
+                bytesWritten,
+                totalBytes: contentLength || undefined,
+            }, exported === tracks.length);
+        } catch (err) {
+            if (!abortController.signal.aborted) {
+                errors.push(`${track.title || `Track ${index + 1}`}: ${err.message || err}`);
+            }
+        }
+    };
+
+    const exportWorker = async () => {
+        while (!abortController.signal.aborted) {
+            const index = nextTrackIndex++;
+            if (index >= tracks.length) return;
+            await exportTrack(index);
+        }
+    };
+    const requestedConcurrency = Math.trunc(Number(request.concurrency)) || 3;
+    const concurrency = Math.min(Math.max(requestedConcurrency, 1), 8, tracks.length);
+    await Promise.all(Array.from({length: concurrency}, () => exportWorker()));
+
+    const m3uEntries = playlistEntries.filter(Boolean).flat();
+    if (!abortController.signal.aborted && errors.length === 0) {
+        const currentFiles = new Set(playlistEntries.filter(Boolean).map((entry) => entry.at(-1)));
+        await replaceTextFile(playlistPath, createM3uFile(request.bitRate, m3uEntries));
+        await Promise.all(
+            [...oldPlaylist.files]
+                .filter((fileName) => !currentFiles.has(fileName))
+                .map((fileName) => fsPromises.rm(path.join(exportDirectory, fileName), {force: true}))
+        );
+    } else if (oldPlaylist.files.size === 0) {
+        await replaceTextFile(playlistPath, createM3uFile(request.bitRate, m3uEntries));
+    }
+    return {
+        canceled: abortController.signal.aborted,
+        exported,
+        skipped: Number(request?.skipped) || 0,
+        errors,
+        destination: exportDirectory,
+    };
+}
+
+function sendProgress(progress, force = false) {
+    const now = Date.now();
+    if (force || now - lastProgressAt >= 100) {
+        lastProgressAt = now;
+        parentPort.postMessage({type: 'progress', progress});
+    }
+}
+
+function sanitizeFileName(value) {
+    const sanitized = String(value)
+        .replace(/[<>:"/\\|?*\u0000-\u001f]/g, '_')
+        .replace(/[. ]+$/g, '')
+        .trim();
+    return sanitized.slice(0, 180) || 'Untitled';
+}
+
+function createM3uEntry(track, fileName) {
+    const displayName = `${track.artist ? `${track.artist} - ` : ''}${track.title || fileName}`;
+    return [
+        `#AMPCAST-ID:${encodeURIComponent(track.id || '')}`,
+        `#EXTINF:${Math.round(track.duration || -1)},${displayName.replace(/[\r\n]/g, ' ')}`,
+        fileName,
+    ];
+}
+
+function getExportFileName(track, index, total) {
+    const prefix = String(index + 1).padStart(String(total).length, '0');
+    const baseName = sanitizeFileName(
+        track.fileName || `${track.title || `Track ${index + 1}`}.mp3`
+    );
+    return `${prefix} - ${baseName}`;
+}
+
+async function isNonEmptyFile(filePath) {
+    try {
+        const stats = await fsPromises.stat(filePath);
+        return stats.isFile() && stats.size > 0;
+    } catch {
+        return false;
+    }
+}
+
+function createM3uFile(bitRate, entries) {
+    return `${[
+        '#EXTM3U',
+        `#AMPCAST:BITRATE=${Number(bitRate)}`,
+        '#AMPCAST:TAGS=1',
+        ...entries,
+    ].join('\r\n')}\r\n`;
+}
+
+async function readManagedPlaylist(playlistPath) {
+    try {
+        const contents = await fsPromises.readFile(playlistPath, 'utf8');
+        const bitRate = Number(contents.match(/^#AMPCAST:BITRATE=(\d+)\r?$/m)?.[1]) || 0;
+        const tagVersion = Number(contents.match(/^#AMPCAST:TAGS=(\d+)\r?$/m)?.[1]) || 0;
+        const entries = [];
+        let id;
+        for (const rawLine of contents.split(/\r?\n/)) {
+            const line = rawLine.trim();
+            if (line.startsWith('#AMPCAST-ID:')) {
+                try {
+                    id = decodeURIComponent(line.slice('#AMPCAST-ID:'.length));
+                } catch {
+                    id = undefined;
+                }
+            } else if (line && !line.startsWith('#') && path.basename(line) === line) {
+                entries.push({id, fileName: line});
+                id = undefined;
+            }
+        }
+        return {bitRate, tagVersion, entries, files: new Set(entries.map(({fileName}) => fileName))};
+    } catch {
+        return {bitRate: 0, tagVersion: 0, files: new Set(), entries: []};
+    }
+}
+
+async function reconcileExportedTrackNames(oldPlaylist, currentTracks, exportDirectory) {
+    const unused = new Set(oldPlaylist.entries);
+    const assignments = [];
+    for (let index = 0; index < currentTracks.length; index++) {
+        const track = currentTracks[index];
+        const desiredName = getExportFileName(track, index, currentTracks.length);
+        const desiredBase = stripTrackPosition(desiredName);
+        let entry = [...unused].find(({id}) => id && id === track.id);
+        entry ||= [...unused].find(
+            ({fileName}) => stripTrackPosition(fileName).toLowerCase() === desiredBase.toLowerCase()
+        );
+        if (!entry) continue;
+        const sourcePath = path.join(exportDirectory, entry.fileName);
+        if (!(await isNonEmptyFile(sourcePath))) continue;
+        unused.delete(entry);
+        if (entry.fileName !== desiredName) {
+            assignments.push({sourcePath, destinationPath: path.join(exportDirectory, desiredName)});
+        }
+    }
+    const staged = [];
+    for (const assignment of assignments) {
+        const temporaryPath = `${assignment.sourcePath}.reorder-${crypto.randomUUID()}`;
+        await fsPromises.rename(assignment.sourcePath, temporaryPath);
+        staged.push({...assignment, temporaryPath});
+    }
+    for (const {temporaryPath, destinationPath} of staged) {
+        await fsPromises.rm(destinationPath, {force: true});
+        await fsPromises.rename(temporaryPath, destinationPath);
+    }
+}
+
+function stripTrackPosition(fileName) {
+    return fileName.replace(/^\d+ - /, '');
+}
+
+async function writeCarCompatibleTags(track, filePath, artworkCache, signal) {
+    const tags = {
+        title: String(track.title || ''),
+        artist: String(track.artist || track.albumArtist || ''),
+        performerInfo: String(track.albumArtist || track.artist || ''),
+        album: String(track.album || ''),
+        trackNumber: track.track ? String(track.track) : undefined,
+        partOfSet: track.disc ? String(track.disc) : undefined,
+        year: track.year ? String(track.year) : undefined,
+    };
+    if (track.artworkUrl) {
+        try {
+            const imageBuffer = await getArtwork(track.artworkUrl, artworkCache, signal);
+            if (imageBuffer) {
+                tags.image = {
+                    mime: 'image/jpeg',
+                    type: {id: 3, name: 'front cover'},
+                    description: 'Cover',
+                    imageBuffer,
+                };
+            }
+        } catch (err) {
+            if (signal.aborted) throw err;
+        }
+    }
+    const result = NodeID3.update(tags, filePath);
+    if (result instanceof Error) throw result;
+}
+
+async function getArtwork(url, cache, signal) {
+    if (!cache.has(url)) {
+        cache.set(url, (async () => {
+            const response = await fetch(url, {redirect: 'follow', signal});
+            if (!response.ok) throw Error(`Artwork HTTP ${response.status}`);
+            const declaredSize = Number(response.headers.get('content-length')) || 0;
+            if (declaredSize > 5 * 1024 * 1024) throw Error('Artwork is larger than 5 MB');
+            const buffer = Buffer.from(await response.arrayBuffer());
+            if (buffer.length > 5 * 1024 * 1024) throw Error('Artwork is larger than 5 MB');
+            return buffer;
+        })());
+    }
+    return cache.get(url);
+}
+
+async function replaceTextFile(filePath, contents) {
+    const partialPath = `${filePath}.part`;
+    await fsPromises.writeFile(partialPath, contents, 'utf8');
+    await fsPromises.rm(filePath, {force: true});
+    await fsPromises.rename(partialPath, filePath);
+}

--- a/app/src/preload.js
+++ b/app/src/preload.js
@@ -13,4 +13,20 @@ contextBridge.exposeInMainWorld('ampcastElectron', {
     getLocalhostIP: () => ipcRenderer.invoke('getLocalhostIP'),
     getPreferredPort: () => ipcRenderer.invoke('getPreferredPort'),
     setPreferredPort: (port) => ipcRenderer.invoke('setPreferredPort', port),
+    exportPlaylist: (request, onProgress) => {
+        const listener = (_, progress) => {
+            if (progress.operationId === request.operationId) {
+                onProgress(progress);
+            }
+        };
+        ipcRenderer.on('export-playlist-progress', listener);
+        return ipcRenderer
+            .invoke('export-playlist', request)
+            .finally(() => ipcRenderer.removeListener('export-playlist-progress', listener));
+    },
+    cancelPlaylistExport: (operationId) =>
+        ipcRenderer.send('cancel-playlist-export', operationId),
+    clearPlaylistExportBatch: (batchId) =>
+        ipcRenderer.send('clear-playlist-export-batch', batchId),
+    getRemovableExportTargets: () => ipcRenderer.invoke('get-removable-export-targets'),
 });

--- a/src/components/Actions/ActionsMenu.tsx
+++ b/src/components/Actions/ActionsMenu.tsx
@@ -222,6 +222,13 @@ function ContextualActions<T extends MediaObject>({
             {item.itemType === ItemType.Playlist ? (
                 <>
                     <PopupMenuSeparator />
+                    {__target__ === 'electron' && service?.id === 'jellyfin' ? (
+                        <PopupMenuItem<Action>
+                            label="Export to MP3…"
+                            value={Action.ExportPlaylist}
+                            key={Action.ExportPlaylist}
+                        />
+                    ) : null}
                     {service?.editPlaylist ? (
                         <PopupMenuItem<Action>
                             label="Edit playlist details…"

--- a/src/components/Actions/performAction.tsx
+++ b/src/components/Actions/performAction.tsx
@@ -12,7 +12,9 @@ import actionsStore from 'services/actions/actionsStore';
 import mediaPlayback from 'services/mediaPlayback';
 import pinStore from 'services/pins/pinStore';
 import playlist from 'services/playlist';
+import exportPlaylist from 'services/playlist/exportPlaylist';
 import {getService, getServiceFromSrc} from 'services/mediaServices';
+import fetchAllTracks from 'services/pagers/fetchAllTracks';
 import stationStore from 'services/internetRadio/stationStore';
 import {confirm, DialogProps, error, showDialog} from 'components/Dialog';
 import {showMediaInfoDialog} from 'components/MediaInfo/MediaInfoDialog';
@@ -92,6 +94,21 @@ export default async function performAction<T extends MediaObject>(
         case Action.EditPlaylist:
             await showEditPlaylistDialog(item as MediaPlaylist);
             break;
+
+        case Action.ExportPlaylist: {
+            const mediaPlaylist = item as MediaPlaylist;
+            try {
+                const tracks = await fetchAllTracks(mediaPlaylist);
+                await exportPlaylist(tracks, mediaPlaylist.title);
+            } catch (err) {
+                logger.error(err);
+                await error({
+                    title: 'Playlist export failed',
+                    message: err instanceof Error ? err.message : String(err),
+                });
+            }
+            break;
+        }
 
         case Action.DeletePlaylist: {
             const playlist = item as MediaPlaylist;

--- a/src/components/Media/Media.scss
+++ b/src/components/Media/Media.scss
@@ -22,6 +22,10 @@
         background: black;
     }
 
+    &.exporting #visualizerPlayer {
+        visibility: hidden;
+    }
+
     /* Fullscreen or mini-player. */
     &.fullscreen {
         /* Actual fullscreen. */

--- a/src/components/Media/Media.tsx
+++ b/src/components/Media/Media.tsx
@@ -15,8 +15,14 @@ import useMouseBusy from 'hooks/useMouseBusy';
 import useOnResize from 'hooks/useOnResize';
 import usePaused from 'hooks/usePaused';
 import useVisualizerSettings from 'hooks/useVisualizerSettings';
+import useObservable from 'hooks/useObservable';
+import {
+    getPlaylistExportState,
+    observePlaylistExportState,
+} from 'services/playlist/playlistExportProgress';
 import Interstitial from './Interstitial';
 import Players from './Players';
+import PlaylistExportProgress from './PlaylistExportProgress';
 import ProgressBar from './ProgressBar';
 import VisualizerControls from './VisualizerControls';
 import useLoadingState from './useLoadingState';
@@ -47,6 +53,7 @@ export default memo(function Media() {
                 loadingState !== 'loading'));
     const isIdle = !useMouseBusy(ref.current, 4000);
     const paused = usePaused();
+    const exportState = useObservable(observePlaylistExportState, getPlaylistExportState());
 
     useEffect(() => {
         const style = ref.current!.style;
@@ -92,7 +99,7 @@ export default memo(function Media() {
                 isShowingCoverArt ? 'is-showing-cover-art' : ''
             } ${isIdle ? 'idle' : ''} ${
                 isFullscreen || isMiniPlayer ? 'fullscreen' : ''
-            } ${miniPlayerActive ? 'mini-player-active' : ''}`}
+            } ${miniPlayerActive ? 'mini-player-active' : ''} ${exportState ? 'exporting' : ''}`}
             id="media"
             onDoubleClick={handleDoubleClick}
             style={style}
@@ -100,6 +107,7 @@ export default memo(function Media() {
         >
             <Players />
             <Interstitial />
+            {exportState ? <PlaylistExportProgress state={exportState} /> : null}
             {(isFullscreen || isMiniPlayer) && fullscreenProgress ? <ProgressBar /> : null}
             <VisualizerControls fullscreen={isFullscreen} onFullscreenToggle={toggleFullscreen} />
         </div>

--- a/src/components/Media/PlaylistExportProgress.scss
+++ b/src/components/Media/PlaylistExportProgress.scss
@@ -1,0 +1,54 @@
+.playlist-export-progress {
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    padding: 2em;
+    background: var(--black);
+    color: var(--soft-white);
+    font-family: var(--system-font-family);
+    text-align: center;
+
+    h2 {
+        margin: 0 0 1em;
+        font-size: max(0.75em, 18px);
+    }
+
+    .export-track-title {
+        width: min(32rem, 80%);
+        margin: 0 0 0.5em;
+        overflow: hidden;
+        font-size: max(0.5em, 14px);
+        text-overflow: ellipsis;
+        white-space: nowrap;
+    }
+
+    progress {
+        width: min(32rem, 80%);
+        height: 1rem;
+        accent-color: var(--frame-text-color);
+    }
+
+    .export-progress-label,
+    .export-queue-label {
+        margin: 0.5em 0 1em;
+        font-size: max(0.45em, 13px);
+        opacity: 0.8;
+    }
+
+    .export-queue-label {
+        margin-top: -0.5em;
+    }
+
+    .export-cancel-button {
+        width: 1.25rem;
+        height: 1.25rem;
+        padding: 0.2rem;
+        border: 1px solid currentColor;
+        border-radius: 50%;
+    }
+}

--- a/src/components/Media/PlaylistExportProgress.tsx
+++ b/src/components/Media/PlaylistExportProgress.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import {PlaylistExportState, cancelPlaylistExport} from 'services/playlist/playlistExportProgress';
+import IconButton from 'components/Button/IconButton';
+import './PlaylistExportProgress.scss';
+
+export interface PlaylistExportProgressProps {
+    state: PlaylistExportState;
+}
+
+export default function PlaylistExportProgress({state}: PlaylistExportProgressProps) {
+    const currentFraction =
+        state.totalBytes && state.totalBytes > 0
+            ? Math.min(state.bytesWritten / state.totalBytes, 1)
+            : 0;
+    const overallProgress = Math.min(
+        (state.completed + currentFraction) / Math.max(state.total, 1),
+        1
+    );
+
+    return (
+        <section className="playlist-export-progress" aria-live="polite">
+            <h2>Exporting “{state.name}” to MP3</h2>
+            <p className="export-track-title">{state.title}</p>
+            <progress value={overallProgress} max={1} />
+            <p className="export-progress-label">
+                {state.canceling
+                    ? 'Canceling…'
+                    : `${state.completed} of ${state.total} tracks completed`}
+            </p>
+            {state.queued ? (
+                <p className="export-queue-label">
+                    {state.queued} playlist{state.queued === 1 ? '' : 's'} queued
+                </p>
+            ) : null}
+            <IconButton
+                className="export-cancel-button"
+                icon="close"
+                aria-label={state.canceling ? 'Canceling export' : 'Cancel export'}
+                title={state.canceling ? 'Canceling…' : 'Cancel export'}
+                disabled={state.canceling}
+                onClick={cancelPlaylistExport}
+            />
+        </section>
+    );
+}

--- a/src/components/MediaControls/PlaylistMenu.tsx
+++ b/src/components/MediaControls/PlaylistMenu.tsx
@@ -47,6 +47,14 @@ export default function PlaylistMenu(props: PopupMenuProps) {
                 disabled={!canSave}
                 key="save-as-playlist"
             />
+            {__target__ === 'electron' ? (
+                <PopupMenuItem
+                    label="Export to MP3…"
+                    value="export-to-usb"
+                    disabled={!canSave}
+                    key="export-to-usb"
+                />
+            ) : null}
             <PopupMenuSeparator />
             <PopupMenuItem label="Add from file…" value="add-from-file" key="add-from-file" />
             <PopupMenuItem label="Add from url…" value="add-from-url" key="add-from-url" />

--- a/src/components/MediaControls/usePlaylistMenu.tsx
+++ b/src/components/MediaControls/usePlaylistMenu.tsx
@@ -8,6 +8,7 @@ import {ListViewHandle} from 'components/ListView';
 import {showCreatePlaylistDialog} from 'components/Actions/CreatePlaylistDialog';
 import {PopupMenuProps, showPopupMenu} from 'components/PopupMenu';
 import usePlaylistInject from 'hooks/usePlaylistInject';
+import exportPlaylist from 'services/playlist/exportPlaylist';
 import PlaylistMenu from './PlaylistMenu';
 
 export default function usePlaylistMenu(listViewRef: React.RefObject<ListViewHandle | null>) {
@@ -93,6 +94,10 @@ export default function usePlaylistMenu(listViewRef: React.RefObject<ListViewHan
 
                 case 'save-as-playlist':
                     await showCreatePlaylistDialog(playlist.getItems());
+                    break;
+
+                case 'export-to-usb':
+                    await exportPlaylist(playlist.getItems());
                     break;
             }
         },

--- a/src/components/Settings/AppSettings/AppPreferences.tsx
+++ b/src/components/Settings/AppSettings/AppPreferences.tsx
@@ -7,7 +7,18 @@ import DialogButtons from 'components/Dialog/DialogButtons';
 export default function AppPreferences() {
     const id = useId();
     const submitted = useRef(false);
-    const originalPreferences = useMemo(() => ({...preferences}), []);
+    const originalPreferences = useMemo(
+        () => ({
+            albumsOrTracks: preferences.albumsOrTracks,
+            disableExplicitContent: preferences.disableExplicitContent,
+            doubleClickBehavior: preferences.doubleClickBehavior,
+            markExplicitContent: preferences.markExplicitContent,
+            mediaInfoTabs: preferences.mediaInfoTabs,
+            miniPlayer: preferences.miniPlayer,
+            spacebarTogglePlay: preferences.spacebarTogglePlay,
+        }),
+        []
+    );
 
     const handleSubmit = useCallback(() => {
         submitted.current = true;

--- a/src/components/Settings/AppSettings/AppSettings.tsx
+++ b/src/components/Settings/AppSettings/AppSettings.tsx
@@ -3,6 +3,7 @@ import TabList, {TabItem} from 'components/TabList';
 import AppSettingsGeneral from './AppSettingsGeneral';
 import AppPreferences from './AppPreferences';
 import AudioSettings from './AudioSettings';
+import PlaylistExportSettings from './PlaylistExportSettings';
 import './AppSettings.scss';
 
 const tabs: TabItem[] = [
@@ -18,6 +19,14 @@ const tabs: TabItem[] = [
         tab: 'Preferences',
         panel: <AppPreferences />,
     },
+    ...(__target__ === 'electron'
+        ? [
+              {
+                  tab: 'Export',
+                  panel: <PlaylistExportSettings />,
+              },
+          ]
+        : []),
 ];
 
 export default function AppSettings() {

--- a/src/components/Settings/AppSettings/PlaylistExportSettings.tsx
+++ b/src/components/Settings/AppSettings/PlaylistExportSettings.tsx
@@ -1,0 +1,125 @@
+import React, {useCallback, useEffect, useId, useMemo, useRef, useState} from 'react';
+import Preferences from 'types/Preferences';
+import preferences from 'services/preferences';
+import DialogButtons from 'components/Dialog/DialogButtons';
+
+export default function PlaylistExportSettings() {
+    const id = useId();
+    const submitted = useRef(false);
+    const originalSettings = useMemo(
+        () => ({
+            askExportBitRate: preferences.askExportBitRate,
+            defaultExportBitRate: preferences.defaultExportBitRate,
+            exportConcurrency: preferences.exportConcurrency,
+            showSimplifiedExportTarget: preferences.showSimplifiedExportTarget,
+        }),
+        []
+    );
+    const [askExportBitRate, setAskExportBitRate] = useState(originalSettings.askExportBitRate);
+
+    const handleSubmit = useCallback(() => {
+        submitted.current = true;
+    }, []);
+
+    useEffect(() => {
+        return () => {
+            if (!submitted.current) {
+                Object.assign(preferences, originalSettings);
+            }
+        };
+    }, [originalSettings]);
+
+    return (
+        <form className="playlist-export-settings" method="dialog" onSubmit={handleSubmit}>
+            <fieldset>
+                <legend>Performance</legend>
+                <div className="table-layout">
+                    <p>
+                        <label htmlFor={`${id}-concurrency`}>Parallel tracks:</label>
+                        <input
+                            type="number"
+                            id={`${id}-concurrency`}
+                            min={1}
+                            max={8}
+                            step={1}
+                            defaultValue={originalSettings.exportConcurrency}
+                            onChange={(e) => {
+                                if (e.target.validity.valid) {
+                                    preferences.exportConcurrency = e.target.valueAsNumber;
+                                }
+                            }}
+                        />
+                    </p>
+                </div>
+                <p>
+                    <small>
+                        Number of Jellyfin tracks transcoded and copied at the same time (1–8).
+                    </small>
+                </p>
+            </fieldset>
+            <fieldset>
+                <legend>MP3 Quality</legend>
+                <div className="table-layout">
+                    <p>
+                        <label htmlFor={`${id}-bit-rate`}>Default bitrate:</label>
+                        <select
+                            id={`${id}-bit-rate`}
+                            defaultValue={originalSettings.defaultExportBitRate}
+                            onChange={(e) =>
+                                (preferences.defaultExportBitRate = Number(
+                                    e.target.value
+                                ) as Preferences['defaultExportBitRate'])
+                            }
+                        >
+                            <option value={128}>128 kbps</option>
+                            <option value={192}>192 kbps</option>
+                            <option value={256}>256 kbps</option>
+                            <option value={320}>320 kbps</option>
+                        </select>
+                    </p>
+                </div>
+                <p>
+                    <input
+                        type="checkbox"
+                        id={`${id}-ask-bit-rate`}
+                        defaultChecked={originalSettings.askExportBitRate}
+                        onChange={(e) => {
+                            preferences.askExportBitRate = e.target.checked;
+                            setAskExportBitRate(e.target.checked);
+                        }}
+                    />
+                    <label htmlFor={`${id}-ask-bit-rate`}>
+                        Ask for bitrate before each export
+                    </label>
+                </p>
+                {!askExportBitRate ? (
+                    <p>
+                        <small>Exports will always use the default bitrate.</small>
+                    </p>
+                ) : null}
+            </fieldset>
+            <fieldset>
+                <legend>Destination</legend>
+                <p>
+                    <input
+                        type="checkbox"
+                        id={`${id}-simplified-target`}
+                        defaultChecked={originalSettings.showSimplifiedExportTarget}
+                        onChange={(e) => {
+                            preferences.showSimplifiedExportTarget = e.target.checked;
+                        }}
+                    />
+                    <label htmlFor={`${id}-simplified-target`}>
+                        Show simplified export target
+                    </label>
+                </p>
+                <p>
+                    <small>
+                        Show a simple list of removable USB drives instead of the folder picker.
+                    </small>
+                </p>
+            </fieldset>
+            <DialogButtons />
+        </form>
+    );
+}

--- a/src/services/emby/embyApi.ts
+++ b/src/services/emby/embyApi.ts
@@ -398,6 +398,35 @@ function getPlayableUrl(item: MediaItem, settings: EmbySettings = embySettings):
     }
 }
 
+function getExportUrl(
+    item: MediaItem,
+    options: {format: 'mp3'; bitRate: number},
+    settings: EmbySettings = embySettings
+): string {
+    const {apiHost, userId, token, deviceId} = settings;
+    if (!apiHost || !userId || !token || !deviceId) {
+        throw Error('Not logged in');
+    }
+    const [, type, id, mediaSourceId] = item.src.split(':');
+    if (type !== 'audio') {
+        throw Error('Only audio tracks can be exported');
+    }
+    const params = new URLSearchParams({
+        static: 'false',
+        container: options.format,
+        audioCodec: options.format,
+        audioBitRate: String(options.bitRate),
+        allowAudioStreamCopy: 'false',
+        allowVideoStreamCopy: 'false',
+        enableAudioVbrEncoding: 'false',
+        mediaSourceId: mediaSourceId || id,
+        userId,
+        deviceId,
+        api_key: token,
+    });
+    return `${apiHost}/Audio/${id}/stream.${options.format}?${params}`;
+}
+
 async function getPlaybackType(
     item: MediaItem,
     settings: EmbySettings = embySettings
@@ -442,6 +471,7 @@ const embyApi = {
     getEndpointInfo,
     getLyrics,
     getMusicLibraries,
+    getExportUrl,
     getPlayableUrl,
     getPlaybackType,
     getSystemInfo,

--- a/src/services/jellyfin/jellyfin.ts
+++ b/src/services/jellyfin/jellyfin.ts
@@ -94,6 +94,7 @@ const jellyfin: PersonalMediaService = {
     getFilters,
     getLyrics,
     getMediaObject,
+    getExportUrl,
     getPlayableUrl,
     getPlaybackType,
     getServerInfo,
@@ -240,6 +241,10 @@ async function getMediaObject<T extends MediaObject>(src: string): Promise<T> {
 
 function getPlayableUrl(item: MediaItem): string {
     return jellyfinApi.getPlayableUrl(item);
+}
+
+function getExportUrl(item: MediaItem, options: {format: 'mp3'; bitRate: number}): string {
+    return jellyfinApi.getExportUrl(item, options);
 }
 
 async function getPlaybackType(item: MediaItem): Promise<PlaybackType> {

--- a/src/services/jellyfin/jellyfinApi.ts
+++ b/src/services/jellyfin/jellyfinApi.ts
@@ -177,6 +177,10 @@ function getPlayableUrl(item: MediaItem): string {
     return embyApi.getPlayableUrl(item, jellyfinSettings);
 }
 
+function getExportUrl(item: MediaItem, options: {format: 'mp3'; bitRate: number}): string {
+    return embyApi.getExportUrl(item, options, jellyfinSettings);
+}
+
 async function getPlaybackType(item: MediaItem): Promise<PlaybackType> {
     return embyApi.getPlaybackType(item, jellyfinSettings);
 }
@@ -197,6 +201,7 @@ const jellyfinApi = {
     getFilters,
     getLyrics,
     getMusicLibraries,
+    getExportUrl,
     getPlayableUrl,
     getPlaybackType,
     getSystemInfo,

--- a/src/services/playlist/exportPlaylist.ts
+++ b/src/services/playlist/exportPlaylist.ts
@@ -1,0 +1,235 @@
+import MediaItem from 'types/MediaItem';
+import ampcastElectron from 'services/ampcastElectron';
+import preferences from 'services/preferences';
+import {getServiceFromSrc} from 'services/mediaServices';
+import {alert, select} from 'components/Dialog';
+import {
+    finishPlaylistExport,
+    setPlaylistExportQueueLength,
+    startPlaylistExport,
+    updatePlaylistExport,
+} from './playlistExportProgress';
+
+interface ExportJob {
+    name: string;
+    run: (batchId: string, destination?: string) => Promise<string>;
+}
+
+const exportQueue: ExportJob[] = [];
+let processingQueue = false;
+
+export default async function exportPlaylist(
+    items: readonly MediaItem[],
+    name = 'Ampcast playlist'
+): Promise<void> {
+    if (!ampcastElectron) {
+        await alert({
+            title: 'Export playlist',
+            message: 'Playlist export is available in the Ampcast desktop app.',
+        });
+        return;
+    }
+    const electron = ampcastElectron;
+    let selectedBitRate = String(preferences.defaultExportBitRate);
+    if (preferences.askExportBitRate) {
+        selectedBitRate = await select({
+            icon: 'jellyfin',
+            title: 'Export playlist to MP3',
+            message: 'Choose the MP3 quality for exported tracks.',
+            options: {
+                '128': 'MP3 — 128 kbps',
+                '192': 'MP3 — 192 kbps',
+                '256': 'MP3 — 256 kbps',
+                '320': 'MP3 — 320 kbps',
+            },
+            suggestedValue: selectedBitRate,
+            okLabel: 'Choose destination',
+        });
+        if (!selectedBitRate) {
+            return;
+        }
+    }
+    const bitRate = Number(selectedBitRate) * 1000;
+
+    const tracks = items.flatMap((item) => {
+        const service = getServiceFromSrc(item);
+        if (!service?.getExportUrl) {
+            return [];
+        }
+        try {
+            const outputName = item.fileName
+                ? item.fileName.replace(/\.[^./\\]+$/, '')
+                : item.title;
+            const url = service.getExportUrl(item, {format: 'mp3', bitRate});
+            return [
+                {
+                    id: item.src,
+                    url,
+                    artworkUrl: getAuthenticatedArtworkUrl(url, item),
+                    fileName: `${outputName}.mp3`,
+                    title: item.title,
+                    artist: item.artists?.join(', ') || item.albumArtist,
+                    albumArtist: item.albumArtist,
+                    album: item.album,
+                    track: item.track,
+                    disc: item.disc,
+                    year: item.year,
+                    duration: item.duration,
+                },
+            ];
+        } catch {
+            return [];
+        }
+    });
+
+    const concurrency = preferences.exportConcurrency;
+    enqueueExport({
+        name,
+        run: async (batchId, destination) => {
+            try {
+                const operationId = crypto.randomUUID();
+                startPlaylistExport(operationId, name, tracks.length, exportQueue.length);
+                const task = electron.exportPlaylist(
+                    {
+                        operationId,
+                        batchId,
+                        bitRate,
+                        name,
+                        concurrency,
+                        destination,
+                        tracks,
+                        skipped: items.length - tracks.length,
+                    },
+                    updatePlaylistExport
+                );
+                const result = await task.finally(() => finishPlaylistExport(operationId));
+                if (result.canceled) {
+                    return `${name}: canceled after ${result.exported} completed track${
+                        result.exported === 1 ? '' : 's'
+                    }.`;
+                }
+
+                const details = [
+                    `${name}: ${result.exported} track${
+                        result.exported === 1 ? '' : 's'
+                    } exported.`,
+                    result.skipped
+                        ? `${result.skipped} unsupported track${
+                              result.skipped === 1 ? '' : 's'
+                          } skipped.`
+                        : '',
+                    result.errors.length
+                        ? `${result.errors.length} download${
+                              result.errors.length === 1 ? '' : 's'
+                          } failed.`
+                        : '',
+                    result.errors[0] || '',
+                ].filter(Boolean);
+                return details.join(' ');
+            } catch (err) {
+                return `${name}: failed — ${err instanceof Error ? err.message : String(err)}`;
+            }
+        },
+    });
+}
+
+function getAuthenticatedArtworkUrl(exportUrl: string, item: MediaItem): string | undefined {
+    const thumbnail = item.thumbnails?.find(({width}) => width >= 480) || item.thumbnails?.at(-1);
+    if (!thumbnail) {
+        return undefined;
+    }
+    try {
+        const artworkUrl = new URL(thumbnail.url);
+        const apiKey = new URL(exportUrl).searchParams.get('api_key');
+        if (apiKey) {
+            artworkUrl.searchParams.set('api_key', apiKey);
+        }
+        artworkUrl.searchParams.set('format', 'jpg');
+        artworkUrl.searchParams.set('quality', '90');
+        return artworkUrl.href;
+    } catch {
+        return undefined;
+    }
+}
+
+function enqueueExport(job: ExportJob): void {
+    exportQueue.push(job);
+    setPlaylistExportQueueLength(exportQueue.length);
+    if (!processingQueue) {
+        void processExportQueue();
+    }
+}
+
+async function processExportQueue(): Promise<void> {
+    processingQueue = true;
+    const batchId = crypto.randomUUID();
+    const summaries: string[] = [];
+    try {
+        let destination: string | undefined;
+        if (preferences.showSimplifiedExportTarget) {
+            let targets;
+            try {
+                targets = await ampcastElectron!.getRemovableExportTargets();
+            } catch (err) {
+                exportQueue.length = 0;
+                setPlaylistExportQueueLength(0);
+                await alert({
+                    title: 'USB drive search failed',
+                    message:
+                        err instanceof Error
+                            ? err.message
+                            : 'Windows did not return the removable drive list.',
+                });
+                return;
+            }
+            if (!targets.length) {
+                exportQueue.length = 0;
+                setPlaylistExportQueueLength(0);
+                await alert({
+                    title: 'No USB drives found',
+                    message: 'Connect a removable USB drive and try the export again.',
+                });
+                return;
+            }
+            const options = Object.fromEntries(
+                targets.map((target) => [
+                    target.path,
+                    `${target.label} (${formatBytes(target.freeBytes)} free)`,
+                ])
+            );
+            destination = await select({
+                icon: 'folder',
+                title: 'Export playlist to MP3',
+                message: 'Choose a removable USB drive.',
+                options,
+                suggestedValue: targets[0].path,
+                okLabel: 'Export here',
+            });
+            if (!destination) {
+                exportQueue.length = 0;
+                setPlaylistExportQueueLength(0);
+                return;
+            }
+        }
+        while (exportQueue.length) {
+            const job = exportQueue.shift()!;
+            setPlaylistExportQueueLength(exportQueue.length);
+            summaries.push(await job.run(batchId, destination));
+        }
+    } finally {
+        processingQueue = false;
+        ampcastElectron?.clearPlaylistExportBatch(batchId);
+    }
+    await alert({
+        title: summaries.length === 1 ? 'Playlist export complete' : 'Playlist exports complete',
+        message: summaries,
+    });
+}
+
+function formatBytes(bytes: number): string {
+    if (!Number.isFinite(bytes) || bytes <= 0) return 'unknown space';
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    const unit = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+    const value = bytes / 1024 ** unit;
+    return `${value.toFixed(value >= 10 || unit === 0 ? 0 : 1)} ${units[unit]}`;
+}

--- a/src/services/playlist/playlistExportProgress.ts
+++ b/src/services/playlist/playlistExportProgress.ts
@@ -1,0 +1,70 @@
+import type {Observable} from 'rxjs';
+import {BehaviorSubject} from 'rxjs';
+import type {PlaylistExportProgress} from 'types/AmpcastElectron';
+import ampcastElectron from 'services/ampcastElectron';
+
+export interface PlaylistExportState extends PlaylistExportProgress {
+    canceling: boolean;
+    name: string;
+    queued: number;
+}
+
+const exportState$ = new BehaviorSubject<PlaylistExportState | null>(null);
+
+export function observePlaylistExportState(): Observable<PlaylistExportState | null> {
+    return exportState$;
+}
+
+export function getPlaylistExportState(): PlaylistExportState | null {
+    return exportState$.value;
+}
+
+export function startPlaylistExport(
+    operationId: string,
+    name: string,
+    total: number,
+    queued: number
+): void {
+    exportState$.next({
+        operationId,
+        completed: 0,
+        total,
+        title: 'Waiting for the first completed track…',
+        bytesWritten: 0,
+        canceling: false,
+        name,
+        queued,
+    });
+}
+
+export function setPlaylistExportQueueLength(queued: number): void {
+    const current = exportState$.value;
+    if (current) {
+        exportState$.next({...current, queued});
+    }
+}
+
+export function updatePlaylistExport(update: PlaylistExportProgress): void {
+    const current = exportState$.value;
+    if (current?.operationId === update.operationId) {
+        exportState$.next({
+            ...current,
+            ...update,
+            title: update.title || current.title,
+        });
+    }
+}
+
+export function cancelPlaylistExport(): void {
+    const current = exportState$.value;
+    if (current && !current.canceling) {
+        exportState$.next({...current, canceling: true});
+        ampcastElectron?.cancelPlaylistExport(current.operationId);
+    }
+}
+
+export function finishPlaylistExport(operationId: string): void {
+    if (exportState$.value?.operationId === operationId) {
+        exportState$.next(null);
+    }
+}

--- a/src/services/preferences.ts
+++ b/src/services/preferences.ts
@@ -7,6 +7,28 @@ import {LiteStorage} from 'utils';
 const storage = new LiteStorage('preferences');
 
 const preferences: Preferences = {
+    get askExportBitRate(): boolean {
+        return storage.getBoolean('askExportBitRate', true);
+    },
+
+    set askExportBitRate(ask: boolean) {
+        storage.setBoolean('askExportBitRate', ask);
+    },
+
+    get defaultExportBitRate(): Preferences['defaultExportBitRate'] {
+        const bitRate = storage.getNumber('defaultExportBitRate', 192);
+        return [128, 192, 256, 320].includes(bitRate)
+            ? (bitRate as Preferences['defaultExportBitRate'])
+            : 192;
+    },
+
+    set defaultExportBitRate(bitRate: Preferences['defaultExportBitRate']) {
+        storage.setNumber(
+            'defaultExportBitRate',
+            [128, 192, 256, 320].includes(bitRate) ? bitRate : 192
+        );
+    },
+
     get albumsOrTracks(): Preferences['albumsOrTracks'] {
         return storage.getString('albumsOrTracks', 'tracks');
     },
@@ -29,6 +51,22 @@ const preferences: Preferences = {
 
     set doubleClickBehavior(behavior: Preferences['doubleClickBehavior']) {
         storage.setString('doubleClickBehavior', behavior);
+    },
+
+    get exportConcurrency(): number {
+        return Math.min(Math.max(Math.round(storage.getNumber('exportConcurrency', 3)), 1), 8);
+    },
+
+    set exportConcurrency(concurrency: number) {
+        storage.setNumber('exportConcurrency', Math.min(Math.max(Math.round(concurrency), 1), 8));
+    },
+
+    get showSimplifiedExportTarget(): boolean {
+        return storage.getBoolean('showSimplifiedExportTarget');
+    },
+
+    set showSimplifiedExportTarget(enabled: boolean) {
+        storage.setBoolean('showSimplifiedExportTarget', enabled);
     },
 
     get markExplicitContent(): boolean {

--- a/src/types/Action.ts
+++ b/src/types/Action.ts
@@ -20,6 +20,7 @@ const enum Action {
     DeletePlaylist = 'delete-playlist',
     DeletePlaylistItems = 'delete-playlist-items',
     EditPlaylist = 'edit-playlist',
+    ExportPlaylist = 'export-playlist',
 }
 
 export default Action;

--- a/src/types/AmpcastElectron.d.ts
+++ b/src/types/AmpcastElectron.d.ts
@@ -1,4 +1,41 @@
 export default interface AmpcastElectron {
+    exportPlaylist(request: {
+        operationId: string;
+        batchId: string;
+        bitRate: number;
+        name: string;
+        concurrency: number;
+        destination?: string;
+        skipped: number;
+        tracks: readonly {
+            id: string;
+            url: string;
+            artworkUrl?: string;
+            fileName?: string;
+            title: string;
+            artist?: string;
+            albumArtist?: string;
+            album?: string;
+            track?: number;
+            disc?: number;
+            year?: number;
+            duration: number;
+        }[];
+    }, onProgress: (progress: PlaylistExportProgress) => void): Promise<{
+        canceled: boolean;
+        exported: number;
+        skipped: number;
+        errors: readonly string[];
+        destination?: string;
+    }>;
+    cancelPlaylistExport(operationId: string): void;
+    clearPlaylistExportBatch(batchId: string): void;
+    getRemovableExportTargets(): Promise<readonly {
+        path: string;
+        label: string;
+        freeBytes: number;
+        totalBytes: number;
+    }[]>;
     disableLoopbackAudio: () => Promise<void>;
     enableLoopbackAudio: () => Promise<void>;
     getCredential(key: string): Promise<string>;
@@ -11,4 +48,13 @@ export default interface AmpcastElectron {
     getPreferredPort(): Promise<number>;
     setPreferredPort(port: number): Promise<void>;
     quit(): void;
+}
+
+export interface PlaylistExportProgress {
+    operationId: string;
+    completed: number;
+    total: number;
+    title?: string;
+    bytesWritten: number;
+    totalBytes?: number;
 }

--- a/src/types/BaseMediaService.d.ts
+++ b/src/types/BaseMediaService.d.ts
@@ -83,6 +83,10 @@ type BaseMediaService = Auth & {
     getFilters?: (filterType: FilterType, itemType: ItemType) => Promise<readonly MediaFilter[]>;
     getLyrics?: (item: MediaItem) => Promise<Lyrics | null>;
     getMediaObject?: <T extends MediaObject>(src: string) => Promise<T>;
+    getExportUrl?: (
+        item: MediaItem,
+        options: {format: 'mp3'; bitRate: number}
+    ) => string;
     getPlayableUrl?: (item: MediaItem) => string;
     getPlaybackType?: (item: MediaItem) => Promise<PlaybackType>;
     getPlaylistByName?: (name: string) => Promise<MediaPlaylist | undefined>;

--- a/src/types/Preferences.d.ts
+++ b/src/types/Preferences.d.ts
@@ -2,8 +2,12 @@ import PlayAction from './PlayAction';
 
 export default interface Preferences {
     albumsOrTracks: 'albums' | 'tracks';
+    askExportBitRate: boolean;
+    defaultExportBitRate: 128 | 192 | 256 | 320;
     disableExplicitContent: boolean;
     doubleClickBehavior: PlayAction;
+    exportConcurrency: number;
+    showSimplifiedExportTarget: boolean;
     markExplicitContent: boolean;
     mediaInfoTabs: boolean;
     miniPlayer: boolean;


### PR DESCRIPTION
## Add playlist export to MP3

This PR adds playlist export functionality to the Ampcast desktop application.

### Features

- Export Jellyfin playlists as MP3 files.
- Selectable bitrate: 128, 192, 256, or 320 kbps.
- Configurable number of parallel exports.
- Background worker processing to keep the interface responsive.
- Export progress with cancellation support.
- Queue additional playlists while an export is running.
- Incremental updates that reuse and reorder existing tracks.
- Remove tracks no longer present in the playlist.
- Generate an M3U8 file preserving playlist order.
- Embed car-stereo-compatible ID3 metadata and cover artwork.
- Choose between the native folder picker and a simplified USB-drive selector on Windows.
- Configure default bitrate and whether to ask for it before each export.